### PR TITLE
Fix cors_allowed_origins

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,7 +39,7 @@ resource "aws_s3_bucket" "default" {
   cors_rule {
     allowed_headers = "${var.cors_allowed_headers}"
     allowed_methods = "${var.cors_allowed_methods}"
-    allowed_origins = "${var.cors_allowed_origins}"
+    allowed_origins = ["${var.cors_allowed_origins}"]
     expose_headers  = "${var.cors_expose_headers}"
     max_age_seconds = "${var.cors_max_age_seconds}"
   }


### PR DESCRIPTION
## what
* Explicitly pass variable as `list` despite already being `list`

## why
* My only guess is there's a bug in TF HCL validation whereby it doesn't detect the input is already a `list`