### PR TITLE
Disambiguate logs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,7 @@ module "logs" {
   name                     = "${var.name}"
   stage                    = "${var.stage}"
   namespace                = "${var.namespace}"
+  attributes               = "${compact(concat(var.attributes, list("logs")))}"
   standard_transition_days = "${var.logs_standard_transition_days}"
   glacier_transition_days  = "${var.logs_glacier_transition_days}"
   expiration_days          = "${var.logs_expiration_days}"
@@ -14,7 +15,7 @@ module "default_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = ["origin"]
+  attributes = "${compact(concat(var.attributes, list("origin")))}"
   tags       = "${var.tags}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -3,7 +3,7 @@ module "logs" {
   name                     = "${var.name}"
   stage                    = "${var.stage}"
   namespace                = "${var.namespace}"
-  attributes               = "${compact(concat(var.attributes, list("logs")))}"
+  attributes               = ["${compact(concat(var.attributes, list("logs")))}"]
   standard_transition_days = "${var.logs_standard_transition_days}"
   glacier_transition_days  = "${var.logs_glacier_transition_days}"
   expiration_days          = "${var.logs_expiration_days}"
@@ -15,7 +15,7 @@ module "default_label" {
   stage      = "${var.stage}"
   name       = "${var.name}"
   delimiter  = "${var.delimiter}"
-  attributes = "${compact(concat(var.attributes, list("origin")))}"
+  attributes = ["${compact(concat(var.attributes, list("origin")))}"]
   tags       = "${var.tags}"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,6 +4,11 @@ variable "namespace" {}
 
 variable "stage" {}
 
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
 variable "tags" {
   type    = "map"
   default = {}


### PR DESCRIPTION
## what
* Add support for `attributes` property (should have been there anyways)
* Disambiguate logs by adding `logs` attribute

## why
* Avoid collisions 