### PR TITLE
Add support for a deployment prefix. Fix deployment_arns

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ module "website_with_cname" {
 | `logs_glacier_transition_days`      | `60`           | Number of days after which to move the data to the glacier storage tier                                         | No       |
 | `logs_expiration_days`              | `90`           | Number of days after which to expunge the objects                                                               | No       |
 | `replication_source_principal_arn`  | `[]`           | List of principal ARNs to grant replication access from different aws account.                                  | No       |
+| `deployment_prefix`                 | `*`            | Wildcard prefix permitted to perform `deployment_actions`                                                       | No       |
 | `deployment_arns`                   | `[]`           | List of ARNs to grant `deployment_actions` permissions on this bucket                                           | No       |
 | `deployment_actions`                | read/write/ls  | List of actions to permit deployment ARNs to perform                                                            | No       |
 

--- a/main.tf
+++ b/main.tf
@@ -10,7 +10,7 @@ module "logs" {
 }
 
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.1"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.2"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"
@@ -64,7 +64,6 @@ resource "aws_s3_bucket" "default" {
       days = "${var.noncurrent_version_expiration_days}"
     }
   }
-
 }
 
 # AWS only supports a single bucket policy on a bucket. You can combine multiple Statements into a single policy, but not attach multiple policies.
@@ -86,6 +85,20 @@ data "aws_iam_policy_document" "default" {
     }
   }]
 
+  # Support deployment ARNs
+  statement {
+    actions = ["${var.deployment_actions}"]
+
+    resources = ["${aws_s3_bucket.default.arn}",
+      "${aws_s3_bucket.default.arn}/${var.deployment_prefix}",
+    ]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["${var.deployment_arns}"]
+    }
+  }
+
   statement = ["${flatten(data.aws_iam_policy_document.replication.*.statement)}"]
 }
 
@@ -94,7 +107,7 @@ data "aws_iam_policy_document" "replication" {
 
   statement {
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = ["${var.replication_source_principal_arn}"]
     }
 
@@ -109,20 +122,6 @@ data "aws_iam_policy_document" "replication" {
       "${aws_s3_bucket.default.arn}",
       "${aws_s3_bucket.default.arn}/*",
     ]
-  }
-
-  # Support deployment ARNs
-  statement {
-    actions = ["${var.deployment_actions}"]
-
-    resources = ["${aws_s3_bucket.default.arn}",
-      "${aws_s3_bucket.default.arn}/*",
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["${var.deployment_arns}"]
-    }
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -107,13 +107,17 @@ variable "replication_source_principal_arn" {
   description = "(Optional) List of principal ARNs to grant replication access from different aws account."
 }
 
-
 variable "versioning_enabled" {
   default = ""
 }
 
 variable "force_destroy" {
   default = ""
+}
+
+variable "deployment_prefix" {
+  description = "(Optional) Wildcard prefix permitted to perform `deployment_actions`"
+  default     = "*"
 }
 
 variable "deployment_arns" {


### PR DESCRIPTION
## what
* Add `deployment_prefix`
* Fix `deployment_arns`

## why
* The `deployment_arns` were used in the wrong section and would get disabled if there were no `replication_arns`
* The `deployment_prefix` allows the user to restrict uploads to a specific path.