### PR TITLE
Add deployment ARNs to S3 path prefixes map

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ module "website_with_cname" {
 | `logs_standard_transition_days`     | `30`           | Number of days to persist in the standard storage tier before moving to the glacier tier                        | No       |
 | `logs_glacier_transition_days`      | `60`           | Number of days after which to move the data to the glacier storage tier                                         | No       |
 | `logs_expiration_days`              | `90`           | Number of days after which to expunge the objects                                                               | No       |
-| `replication_source_principal_arn`  | `[]`           | List of principal ARNs to grant replication access from different AWS accounts                                  | No       |
+| `replication_source_principal_arns` | `[]`           | List of principal ARNs to grant replication access from different AWS accounts                                  | No       |
 | `deployment_arns`                   | `{}`           | Map of deployment ARNs to S3 prefixes to grant `deployment_actions` permissions                                 | No       |
 | `deployment_actions`                | read/write/ls  | List of actions to permit deployment ARNs to perform                                                            | No       |
 

--- a/README.md
+++ b/README.md
@@ -68,9 +68,8 @@ module "website_with_cname" {
 | `logs_standard_transition_days`     | `30`           | Number of days to persist in the standard storage tier before moving to the glacier tier                        | No       |
 | `logs_glacier_transition_days`      | `60`           | Number of days after which to move the data to the glacier storage tier                                         | No       |
 | `logs_expiration_days`              | `90`           | Number of days after which to expunge the objects                                                               | No       |
-| `replication_source_principal_arn`  | `[]`           | List of principal ARNs to grant replication access from different aws account.                                  | No       |
-| `deployment_prefix`                 | `*`            | Wildcard prefix permitted to perform `deployment_actions`                                                       | No       |
-| `deployment_arns`                   | `[]`           | List of ARNs to grant `deployment_actions` permissions on this bucket                                           | No       |
+| `replication_source_principal_arn`  | `[]`           | List of principal ARNs to grant replication access from different AWS accounts                                  | No       |
+| `deployment_arns`                   | `{}`           | Map of deployment ARNs to S3 prefixes to grant `deployment_actions` permissions                                 | No       |
 | `deployment_actions`                | read/write/ls  | List of actions to permit deployment ARNs to perform                                                            | No       |
 
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-s3-website
 
-Terraform module for Creating S3 backed Websites
+Terraform module for creating S3 backed Websites
 
 ## Further Reading
 
@@ -69,6 +69,7 @@ module "website_with_cname" {
 | `logs_glacier_transition_days`      | `60`           | Number of days after which to move the data to the glacier storage tier                                         | No       |
 | `logs_expiration_days`              | `90`           | Number of days after which to expunge the objects                                                               | No       |
 | `replication_source_principal_arn`  | `[]`           | List of principal ARNs to grant replication access from different aws account.                                  | No       |
+| `deployment_prefix`                 | `*`            | Wildcard prefix permitted to perform `deployment_actions`                                                       | No       |
 | `deployment_arns`                   | `[]`           | List of ARNs to grant `deployment_actions` permissions on this bucket                                           | No       |
 | `deployment_actions`                | read/write/ls  | List of actions to permit deployment ARNs to perform                                                            | No       |
 

--- a/main.tf
+++ b/main.tf
@@ -93,12 +93,12 @@ data "aws_iam_policy_document" "default" {
 }
 
 data "aws_iam_policy_document" "replication" {
-  count = "${signum(length(var.replication_source_principal_arn))}"
+  count = "${signum(length(var.replication_source_principal_arns))}"
 
   statement {
     principals {
       type        = "AWS"
-      identifiers = ["${var.replication_source_principal_arn}"]
+      identifiers = ["${var.replication_source_principal_arns}"]
     }
 
     actions = [

--- a/variables.tf
+++ b/variables.tf
@@ -109,7 +109,7 @@ variable "force_destroy" {
   default = ""
 }
 
-variable "replication_source_principal_arn" {
+variable "replication_source_principal_arns" {
   type        = "list"
   default     = []
   description = "(Optional) List of principal ARNs to grant replication access from different AWS accounts"

--- a/variables.tf
+++ b/variables.tf
@@ -101,12 +101,6 @@ variable "region" {
   default = ""
 }
 
-variable "replication_source_principal_arn" {
-  type        = "list"
-  default     = []
-  description = "(Optional) List of principal ARNs to grant replication access from different aws account."
-}
-
 variable "versioning_enabled" {
   default = ""
 }
@@ -115,25 +109,20 @@ variable "force_destroy" {
   default = ""
 }
 
-variable "deployment_prefix" {
-  description = "(Optional) Wildcard prefix permitted to perform `deployment_actions`"
-  default     = "*"
+variable "replication_source_principal_arn" {
+  type        = "list"
+  default     = []
+  description = "(Optional) List of principal ARNs to grant replication access from different AWS accounts"
 }
 
 variable "deployment_arns" {
-  description = "(Optional) List of ARNs to grant `deployment_actions` permissions on this bucket"
-  type        = "list"
-  default     = []
+  type        = "map"
+  default     = {}
+  description = "(Optional) Map of deployment ARNs to S3 prefixes to grant `deployment_actions` permissions"
 }
 
 variable "deployment_actions" {
-  description = "List of actions to permit deployment ARNs to perform"
   type        = "list"
   default     = ["s3:PutObject", "s3:PutObjectAcl", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket", "s3:ListBucketMultipartUploads", "s3:GetBucketLocation", "s3:AbortMultipartUpload"]
-}
-
-variable "deployment_arns_deployment_prefixes" {
-  type        = "map"
-  default     = {}
-  description = "Map of deployments ARNs to S3 prefixes to allow the `deployment_actions` to be executed by the ARNs on the deployment prefixes"
+  description = "List of actions to permit deployment ARNs to perform"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -107,13 +107,17 @@ variable "replication_source_principal_arn" {
   description = "(Optional) List of principal ARNs to grant replication access from different aws account."
 }
 
-
 variable "versioning_enabled" {
   default = ""
 }
 
 variable "force_destroy" {
   default = ""
+}
+
+variable "deployment_prefix" {
+  description = "(Optional) Wildcard prefix permitted to perform `deployment_actions`"
+  default     = "*"
 }
 
 variable "deployment_arns" {
@@ -126,4 +130,10 @@ variable "deployment_actions" {
   description = "List of actions to permit deployment ARNs to perform"
   type        = "list"
   default     = ["s3:PutObject", "s3:PutObjectAcl", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket", "s3:ListBucketMultipartUploads", "s3:GetBucketLocation", "s3:AbortMultipartUpload"]
+}
+
+variable "deployment_arns_deployment_prefixes" {
+  type        = "map"
+  default     = {}
+  description = "Map of deployments ARNs to S3 prefixes to allow the `deployment_actions` to be executed by the ARNs on the deployment prefixes"
 }


### PR DESCRIPTION
## what
* Changed `deployment_arns` from list of ARNs to map of ARNs to S3 path prefixes

## why
* To separately grant `deployment_actions` permissions to the specific ARNs only for the specific paths