### PR TITLE
Change format of `deployment_arns` to map of ARNs to lists of S3 prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,16 @@ Terraform module for creating S3 backed Websites
 
 ```hcl
 module "website" {
-  source      = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=master"
-  namespace   = "${var.namespace}"
-  stage       = "${var.stage}"
-  name        = "${var.name}"
-  hostname    = "${var.hostname}"
+  source    = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=master"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.name}"
+  hostname  = "${var.hostname}"
+
+  deployment_arns = {
+    "arn:aws:s3:::principal1" = ["/prefix1", "/prefix2"]
+    "arn:aws:s3:::principal2" = [""]
+  }
 }
 ```
 
@@ -69,7 +74,7 @@ module "website_with_cname" {
 | `logs_glacier_transition_days`      | `60`           | Number of days after which to move the data to the glacier storage tier                                         | No       |
 | `logs_expiration_days`              | `90`           | Number of days after which to expunge the objects                                                               | No       |
 | `replication_source_principal_arns` | `[]`           | List of principal ARNs to grant replication access from different AWS accounts                                  | No       |
-| `deployment_arns`                   | `{}`           | Map of deployment ARNs to S3 prefixes to grant `deployment_actions` permissions                                 | No       |
+| `deployment_arns`                   | `{}`           | Map of deployment ARNs to lists of S3 path prefixes to grant `deployment_actions` permissions                   | No       |
 | `deployment_actions`                | read/write/ls  | List of actions to permit deployment ARNs to perform                                                            | No       |
 
 

--- a/main.tf
+++ b/main.tf
@@ -123,8 +123,8 @@ data "aws_iam_policy_document" "deployment" {
     actions = ["${var.deployment_actions}"]
 
     resources = [
-      "${aws_s3_bucket.default.arn}",
-      "${aws_s3_bucket.default.arn}/${lookup(var.deployment_arns, element(keys(var.deployment_arns), count.index))}",
+      "${formatlist("${aws_s3_bucket.default.arn}%s", var.deployment_arns[element(keys(var.deployment_arns), count.index)])}",
+      "${formatlist("${aws_s3_bucket.default.arn}%s/*", var.deployment_arns[element(keys(var.deployment_arns), count.index)])}",
     ]
 
     principals {

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "replication_source_principal_arns" {
 variable "deployment_arns" {
   type        = "map"
   default     = {}
-  description = "(Optional) Map of deployment ARNs to S3 prefixes to grant `deployment_actions` permissions"
+  description = "(Optional) Map of deployment ARNs to lists of S3 path prefixes to grant `deployment_actions` permissions"
 }
 
 variable "deployment_actions" {


### PR DESCRIPTION
## what
* Changed format of `deployment_arns` to __map of ARNs to lists of S3 prefixes__

## why
* To be able to grant an ARN the deployment actions permissions on more than one S3 path

## test
given the following `deployment_arns` map
```hcl
variable "deployment_arns" {
  default     = {
    "arn:aws:s3:::principal3" = ["/prefix1", "/prefix2"]
    "arn:aws:s3:::principal4" = [""]
  }
}
```

the generated policy looks like this:
```js
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Sid": "AllowGetObject",
      "Effect": "Allow",
      "Action": "s3:GetObject",
      "Resource": "arn:aws:s3:::bucket1/*",
      "Principal": "*"
    },
    {
      "Sid": "AllowReplication",
      "Effect": "Allow",
      "Action": [
        "s3:ReplicateObject",
        "s3:ReplicateDelete",
        "s3:PutBucketVersioning",
        "s3:GetBucketVersioning"
      ],
      "Resource": [
        "arn:aws:s3:::bucket1/*",
        "arn:aws:s3:::bucket1"
      ],
      "Principal": {
        "AWS": [
          "arn:aws:s3:::principal2",
          "arn:aws:s3:::principal1"
        ]
      }
    },
    {
      "Sid": "AllowDeployment",
      "Effect": "Allow",
      "Action": [
        "s3:PutObjectAcl",
        "s3:PutObject",
        "s3:ListBucketMultipartUploads",
        "s3:ListBucket",
        "s3:GetObject",
        "s3:GetBucketLocation",
        "s3:DeleteObject",
        "s3:AbortMultipartUpload"
      ],
      "Resource": [
        "arn:aws:s3:::bucket1/prefix2/*",
        "arn:aws:s3:::bucket1/prefix2",
        "arn:aws:s3:::bucket1/prefix1/*",
        "arn:aws:s3:::bucket1/prefix1"
      ],
      "Principal": {
        "AWS": "arn:aws:s3:::principal3"
      }
    },
    {
      "Sid": "AllowDeployment",
      "Effect": "Allow",
      "Action": [
        "s3:PutObjectAcl",
        "s3:PutObject",
        "s3:ListBucketMultipartUploads",
        "s3:ListBucket",
        "s3:GetObject",
        "s3:GetBucketLocation",
        "s3:DeleteObject",
        "s3:AbortMultipartUpload"
      ],
      "Resource": [
        "arn:aws:s3:::bucket1/*",
        "arn:aws:s3:::bucket1"
      ],
      "Principal": {
        "AWS": "arn:aws:s3:::principal4"
      }
    }
  ]
}
```
