### PR TITLE
Remove `sid` from `aws_iam_policy_document`, let AWS generate them

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -119,7 +119,6 @@ data "aws_iam_policy_document" "deployment" {
   count = "${length(keys(var.deployment_arns))}"
 
   statement {
-    sid     = "AllowDeployment"
     actions = ["${var.deployment_actions}"]
 
     resources = [


### PR DESCRIPTION
## what
* Remove `sid` from `aws_iam_policy_document`, let AWS generate them

## why
* To prevent `sid` duplication
