### PR TITLE
Add `website_endpoint` output. Add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+addons:
+  apt:
+    packages:
+      - git
+      - make
+      - curl
+
+install:
+  - make init
+
+script:
+  - make terraform/install
+  - make terraform/get-plugins
+  - make terraform/get-modules
+  - make terraform/lint
+  - make terraform/validate

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2017 Cloud Posse, LLC 
+   Copyright 2017-2018 Cloud Posse, LLC
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+SHELL := /bin/bash
+
+-include $(shell curl -sSL -o .build-harness "https://git.io/build-harness"; echo .build-harness)
+
+lint:
+	$(SELF) terraform/install terraform/get-modules terraform/get-plugins terraform/lint terraform/validate

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# terraform-aws-s3-website
+# terraform-aws-s3-website [![Build Status](https://travis-ci.org/cloudposse/terraform-aws-s3-website.svg?branch=master)](https://travis-ci.org/cloudposse/terraform-aws-s3-website)
 
-Terraform module for creating S3 backed Websites
+Terraform module to provision S3-backed Websites
+
 
 ## Further Reading
 
@@ -14,10 +15,10 @@ Terraform module for creating S3 backed Websites
 ```hcl
 module "website" {
   source    = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=master"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
-  hostname  = "${var.hostname}"
+  namespace = "cp"
+  stage     = "prod"
+  name      = "app"
+  hostname  = "docs.prod.cloudposse.org"
 
   deployment_arns = {
     "arn:aws:s3:::principal1" = ["/prefix1", "/prefix2"]
@@ -26,18 +27,19 @@ module "website" {
 }
 ```
 
-#### Create S3 Website Bucket with Route53 DNS
+
+#### Create S3 website bucket with Route53 DNS
 
 * Required one of the `parent_zone_id` or `parent_zone_name`
 
 ```hcl
 module "website_with_cname" {
   source         = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=master"
-  namespace      = "${var.namespace}"
-  stage          = "${var.stage}"
-  name           = "${var.name}"
-  hostname       = "${var.hostname}"
-  parent_zone_id = "${var.parent_zone_id}"
+  namespace      = "cp"
+  stage          = "prod"
+  name           = "app"
+  hostname       = "docs.prod.cloudposse.org"
+  parent_zone_id = "XXXXXXXXXXXX"
 }
 ```
 
@@ -48,10 +50,10 @@ module "website_with_cname" {
 |:------------------------------------|:--------------:|:----------------------------------------------------------------------------------------------------------------|:--------:|
 | `namespace`                         | ``             | Namespace (e.g. `cp` or `cloudposse`)                                                                           | Yes      |
 | `stage`                             | ``             | Stage (e.g. `prod`, `dev`, `staging`)                                                                           | Yes      |
-| `name`                              | ``             | Name  (e.g. `bastion` or `db`)                                                                                  | Yes      |
-| `attributes`                        | `[]`           | Additional attributes (e.g. `policy` or `role`)                                                                 | No       |
+| `name`                              | ``             | Name  (e.g. `app`)                                                                                              | Yes      |
+| `attributes`                        | `[]`           | Additional attributes (e.g. `1`)                                                                                | No       |
 | `tags`                              | `{}`           | Additional tags  (e.g. `map("BusinessUnit","XYZ")`                                                              | No       |
-| `delimiter`                         | `-`            | Delimiter to be used between `name`, `namespace`, `stage`, `arguments`, etc.                                    | No       |
+| `delimiter`                         | `-`            | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`                                      | No       |
 | `hostname`                          | `[]`           | Name of website bucket in `fqdn` format (e.g. `test.example.com`). IMPORTANT! Do not add trailing dot (`.`)     | Yes      |
 | `parent_zone_id`                    | ``             | ID of the hosted zone to contain the record or specify `parent_zone_name` instead                               | No       |
 | `parent_zone_name`                  | ``             | Name of the hosted zone to contain the record or specify `parent_zone_id` instead                               | No       |
@@ -82,11 +84,94 @@ module "website_with_cname" {
 
 | Name                           | Description                                                 |
 |:------------------------------ |:------------------------------------------------------------|
-| `hostname`                     | Assigned DNS-record to the DNS-record of website bucket     |
-| `s3_bucket_domain_name`        | DNS-record of website bucket                                |
+| `hostname`                     | Bucket hostname                                             |
+| `s3_bucket_domain_name`        | DNS record of website bucket                                |
 | `s3_bucket_name`               | Name of of website bucket                                   |
+| `s3_bucket_arn`                | Name of of website bucket                                   |
+| `s3_bucket_website_endpoint`   | The website endpoint URL                                    |
+| `s3_bucket_website_domain`     | The domain of the website endpoint                          |
+| `s3_bucket_hosted_zone_id`     | The Route 53 Hosted Zone ID for this bucket's region        |
+
+
+## Help
+
+**Got a question?**
+
+File a GitHub [issue](https://github.com/cloudposse/terraform-aws-s3-website/issues), send us an [email](mailto:hello@cloudposse.com) or reach out to us on [Gitter](https://gitter.im/cloudposse/).
+
+
+## Contributing
+
+### Bug Reports & Feature Requests
+
+Please use the [issue tracker](https://github.com/cloudposse/terraform-aws-s3-website/issues) to report any bugs or file feature requests.
+
+### Developing
+
+If you are interested in being a contributor and want to get involved in developing `terraform-aws-s3-website`, we would love to hear from you! Shoot us an [email](mailto:hello@cloudposse.com).
+
+In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
+
+ 1. **Fork** the repo on GitHub
+ 2. **Clone** the project to your own machine
+ 3. **Commit** changes to your own branch
+ 4. **Push** your work back up to your fork
+ 5. Submit a **Pull request** so that we can review your changes
+
+**NOTE:** Be sure to merge the latest from "upstream" before making a pull request!
 
 
 ## License
 
-Apache 2 License. See [`LICENSE`](LICENSE) for full details.
+[APACHE 2.0](LICENSE) © 2017-2018 [Cloud Posse, LLC](https://cloudposse.com)
+
+See [LICENSE](LICENSE) for full details.
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+
+## About
+
+`terraform-aws-s3-website` is maintained and funded by [Cloud Posse, LLC][website].
+
+![Cloud Posse](https://cloudposse.com/logo-300x69.png)
+
+
+Like it? Please let us know at <hello@cloudposse.com>
+
+We love [Open Source Software](https://github.com/cloudposse/)!
+
+See [our other projects][community]
+or [hire us][hire] to help build your next cloud platform.
+
+  [website]: https://cloudposse.com/
+  [community]: https://github.com/cloudposse/
+  [hire]: https://cloudposse.com/contact/
+
+
+## Contributors
+
+| [![Erik Osterman][erik_img]][erik_web]<br/>[Erik Osterman][erik_web] | [![Andriy Knysh][andriy_img]][andriy_web]<br/>[Andriy Knysh][andriy_web] |[![Igor Rodionov][igor_img]][igor_web]<br/>[Igor Rodionov][igor_img]
+|-------------------------------------------------------|------------------------------------------------------------------|------------------------------------------------------------------|
+
+[erik_img]: http://s.gravatar.com/avatar/88c480d4f73b813904e00a5695a454cb?s=144
+[erik_web]: https://github.com/osterman/
+[andriy_img]: https://avatars0.githubusercontent.com/u/7356997?v=4&u=ed9ce1c9151d552d985bdf5546772e14ef7ab617&s=144
+[andriy_web]: https://github.com/aknysh/
+[igor_img]: http://s.gravatar.com/avatar/bc70834d32ed4517568a1feb0b9be7e2?s=144
+[igor_web]: https://github.com/goruha/

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.1.2"
+  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.2.0"
   name                     = "${var.name}"
   stage                    = "${var.stage}"
   namespace                = "${var.namespace}"
@@ -10,7 +10,7 @@ module "logs" {
 }
 
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.2.2"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.3.3"
   namespace  = "${var.namespace}"
   stage      = "${var.stage}"
   name       = "${var.name}"

--- a/output.tf
+++ b/output.tf
@@ -1,3 +1,7 @@
+output "hostname" {
+  value = "${var.hostname}"
+}
+
 output "s3_bucket_name" {
   value = "${aws_s3_bucket.default.id}"
 }
@@ -6,6 +10,18 @@ output "s3_bucket_domain_name" {
   value = "${aws_s3_bucket.default.bucket_domain_name}"
 }
 
-output "hostname" {
-  value = "${var.hostname}"
+output "s3_bucket_arn" {
+  value = "${aws_s3_bucket.default.arn}"
+}
+
+output "s3_bucket_website_endpoint" {
+  value = "${aws_s3_bucket.default.website_endpoint}"
+}
+
+output "s3_bucket_website_domain" {
+  value = "${aws_s3_bucket.default.website_domain}"
+}
+
+output "s3_bucket_hosted_zone_id" {
+  value = "${aws_s3_bucket.default.hosted_zone_id}"
 }


### PR DESCRIPTION
## what
* Add `website_endpoint` output
* Add TravisCI

## why
* Since the module creates S3-backed websites, the website URL output is needed (to be used in other Terraform modules, e.g. as an Origin for CloudFront distribution)
* To lint Terraform code and monitor builds
