### PR TITLE
Terraform 0.14 upgrade

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Use this file to define individuals or teams that are responsible for code in a repository.
 # Read more: <https://help.github.com/articles/about-codeowners/>
 #
-# Order is important: the last matching pattern takes the most precedence
+# Order is important: the last matching pattern has the highest precedence
 
 # These owners will be the default owners for everything
 *             @cloudposse/engineering @cloudposse/contributors
@@ -12,3 +12,13 @@
 
 # Cloud Posse must review any changes to GitHub actions
 .github/*     @cloudposse/engineering
+
+# Cloud Posse must review any changes to standard context definition,
+# but some changes can be rubber-stamped.
+**/context.tf   @cloudposse/engineering @cloudposse/approvers
+README.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+docs/*.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+
+# Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
+.github/mergify.yml @cloudposse/admins
+.github/CODEOWNERS  @cloudposse/admins

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -4,30 +4,35 @@ version-template: '$MAJOR.$MINOR.$PATCH'
 version-resolver:
   major:
     labels:
-      - 'major'
+    - 'major'
   minor:
     labels:
-      - 'minor'
-      - 'enhancement'
+    - 'minor'
+    - 'enhancement'
   patch:
     labels:
-      - 'patch'
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-      - 'hotfix'
+    - 'auto-update'
+    - 'patch'
+    - 'fix'
+    - 'bugfix'
+    - 'bug'
+    - 'hotfix'
   default: 'minor'
 
 categories:
-  - title: '🚀 Enhancements'
-    labels:
-      - 'enhancement'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-      - 'hotfix'
+- title: '🚀 Enhancements'
+  labels:
+  - 'enhancement'
+  - 'patch'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+  - 'hotfix'
+- title: '🤖 Automatic Updates'
+  labels:
+  - 'auto-update'
 
 change-template: |
   <details>

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,52 @@
+pull_request_rules:
+- name: "approve automated PRs that have passed checks"
+  conditions:
+  - "check-success~=test/bats"
+  - "check-success~=test/readme"
+  - "check-success~=test/terratest"
+  - "base=master"
+  - "author=cloudpossebot"
+  - "head~=auto-update/.*"
+  actions:
+    review:
+      type: "APPROVE"
+      bot_account: "cloudposse-mergebot"
+      message: "We've automatically approved this PR because the checks from the automated Pull Request have passed."
+
+- name: "merge automated PRs when approved and tests pass"
+  conditions:
+  - "check-success~=test/bats"
+  - "check-success~=test/readme"
+  - "check-success~=test/terratest"
+  - "base=master"
+  - "head~=auto-update/.*"
+  - "#approved-reviews-by>=1"
+  - "#changes-requested-reviews-by=0"
+  - "#commented-reviews-by=0"
+  - "base=master"
+  - "author=cloudpossebot"
+  actions:
+    merge:
+      method: "squash"
+
+- name: "delete the head branch after merge"
+  conditions:
+  - "merged"
+  actions:
+    delete_head_branch: {}
+
+- name: "ask to resolve conflict"
+  conditions:
+  - "conflict"
+  actions:
+    comment:
+      message: "This pull request is now in conflict. Could you fix it @{{author}}? 🙏"
+
+- name: "remove outdated reviews"
+  conditions:
+  - "base=master"
+  actions:
+    dismiss_reviews:
+      changes_requested: true
+      approved: true
+      message: "This Pull Request has been updated, so we're dismissing all reviews."

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "config:base",
+    ":preserveSemverRanges"
+  ],
+  "labels": ["auto-update"],
+  "enabledManagers": ["terraform"],
+  "terraform": {
+    "ignorePaths": ["**/context.tf", "examples/**"]
+  }
+}
+

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -1,0 +1,55 @@
+name: "auto-context"
+on:
+  schedule:
+  # Update context.tf nightly
+  - cron:  '0 3 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update context.tf
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        if [[ -f context.tf ]]; then
+          echo "Discovered existing context.tf! Fetching most recent version to see if there is an update."
+          curl -o context.tf -fsSL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf
+          if git diff --no-patch --exit-code context.tf; then
+            echo "No changes detected! Exiting the job..."
+          else
+            echo "context.tf file has changed. Update examples and rebuild README.md."
+            make init
+            make github/init/context.tf
+            make readme/build
+            echo "::set-output name=create_pull_request=true"
+          fi
+        else
+          echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
+        fi
+
+    - name: Create Pull Request
+      if: steps.update.outputs.create_pull_request == 'true'
+      uses: cloudposse/actions/github/create-pull-request@0.22.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update context.tf from origin source
+        title: Update context.tf
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the `context.tf` file to the latest version from `cloudposse/terraform-null-label`
+
+          ## why
+          To support all the features of the `context` interface.
+
+        branch: auto-update/context.tf
+        base: master
+        delete-branch: true
+        labels: |
+          auto-update
+          context

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,0 +1,41 @@
+name: "auto-readme"
+on:
+  schedule:
+  # Update README.md nightly
+  - cron:  '0 4 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update readme
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        make init
+        make readme/build
+
+    - name: Create Pull Request
+      uses: cloudposse/actions/github/create-pull-request@0.20.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update README.md and docs
+        title: Update README.md and docs
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the README.md and docs
+
+          ## why
+          To have most recent changes of README.md and doc from origin templates
+
+        branch: auto-update/readme
+        base: master
+        delete-branch: true
+        labels: |
+          auto-update
+          readme

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,17 @@ name: auto-release
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          publish: true
-          prerelease: false
-          config-name: auto-release.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: true
+        prerelease: false
+        config-name: auto-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "Handle common commands"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.16.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}
@@ -24,7 +24,7 @@ jobs:
       - name: "Checkout commit"
         uses: actions/checkout@v2
       - name: "Run tests"
-        uses: cloudposse/actions/github/slash-command-dispatch@0.16.0
+        uses: cloudposse/actions/github/slash-command-dispatch@0.22.0
         with:
           token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
           reaction-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,0 +1,25 @@
+name: Validate Codeowners
+on:
+  pull_request:
+
+jobs:
+  validate-codeowners:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout source code at current commit"
+      uses: actions/checkout@v2
+    - uses: mszostok/codeowners-validator@v0.5.0
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      name: "Full check of CODEOWNERS"
+      with:
+        # For now, remove "files" check to allow CODEOWNERS to specify non-existent
+        # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
+        #   checks: "files,syntax,owners,duppatterns"
+        checks: "syntax,owners,duppatterns"
+        # GitHub access token is required only if the `owners` check is enabled
+        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+    - uses: mszostok/codeowners-validator@v0.5.0
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      name: "Syntax check of CODEOWNERS"
+      with:
+        checks: "syntax,duppatterns"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+<!-- markdownlint-disable -->
 # terraform-aws-s3-website [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-s3-website.svg)](https://github.com/cloudposse/terraform-aws-s3-website/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
+<!-- markdownlint-restore -->
 
 [![README Header][readme_header_img]][readme_header_link]
 
@@ -62,15 +64,24 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
-**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
-Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-s3-website/releases).
+**IMPORTANT:** We do not pin modules to versions in our examples because of the
+difficulty of keeping the versions in the documentation in sync with the latest released versions.
+We highly recommend that in your code you pin the version to the exact version you are
+using so that your infrastructure remains stable, and update versions in a
+systematic way so that they do not catch you by surprise.
+
+Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
+the registry shows many of our inputs as required when in fact they are optional.
+The table below correctly indicates which inputs are required.
 
 
 #### Create s3 website bucket
 
 ```hcl
 module "website" {
-  source    = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=master"
+  source = "cloudposse/s3-website/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version = "x.x.x"
   namespace = "eg"
   stage     = "prod"
   name      = "app"
@@ -90,7 +101,9 @@ Required one of the `parent_zone_id` or `parent_zone_name`
 
 ```hcl
 module "website_with_cname" {
-  source         = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=master"
+  source = "cloudposse/s3-website/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version = "x.x.x"
   namespace      = "eg"
   stage          = "prod"
   name           = "app"
@@ -116,26 +129,29 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
+| terraform | >= 0.12.26 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | `list(string)` | `[]` | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | cors\_allowed\_headers | List of allowed headers | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | cors\_allowed\_methods | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br>  "GET"<br>]</pre> | no |
 | cors\_allowed\_origins | List of allowed origins (e.g. example.com, test.com) | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
@@ -144,10 +160,14 @@ Available targets:
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | `string` | `"-"` | no |
 | deployment\_actions | List of actions to permit deployment ARNs to perform | `list(string)` | <pre>[<br>  "s3:PutObject",<br>  "s3:PutObjectAcl",<br>  "s3:GetObject",<br>  "s3:DeleteObject",<br>  "s3:ListBucket",<br>  "s3:ListBucketMultipartUploads",<br>  "s3:GetBucketLocation",<br>  "s3:AbortMultipartUpload"<br>]</pre> | no |
 | deployment\_arns | (Optional) Map of deployment ARNs to lists of S3 path prefixes to grant `deployment_actions` permissions | `map(any)` | `{}` | no |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | error\_document | An absolute path to the document to return in case of a 4XX error | `string` | `"404.html"` | no |
 | force\_destroy | Delete all objects from the bucket so that the bucket can be destroyed without error (e.g. `true` or `false`) | `bool` | `false` | no |
 | hostname | Name of website bucket in `fqdn` format (e.g. `test.example.com`). IMPORTANT! Do not add trailing dot (`.`) | `string` | n/a | yes |
+| id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | index\_document | Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders | `string` | `"index.html"` | no |
+| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | lifecycle\_rule\_enabled | Enable or disable lifecycle rule | `bool` | `false` | no |
 | logs\_expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
 | logs\_glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
@@ -160,6 +180,7 @@ Available targets:
 | parent\_zone\_name | Name of the hosted zone to contain the record | `string` | `""` | no |
 | prefix | Prefix identifying one or more objects to which the rule applies | `string` | `""` | no |
 | redirect\_all\_requests\_to | A hostname to redirect all website requests for this bucket to. If this is set `index_document` will be ignored | `string` | `""` | no |
+| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | region | AWS region this bucket should reside in | `string` | `""` | no |
 | replication\_source\_principal\_arns | (Optional) List of principal ARNs to grant replication access from different AWS accounts | `list(string)` | `[]` | no |
 | routing\_rules | A json array containing routing rules describing redirect behavior and when redirects are applied | `string` | `""` | no |
@@ -179,6 +200,7 @@ Available targets:
 | s3\_bucket\_website\_domain | The domain of the website endpoint |
 | s3\_bucket\_website\_endpoint | The website endpoint URL |
 
+<!-- markdownlint-restore -->
 
 
 
@@ -337,8 +359,10 @@ Check out [our other projects][github], [follow us on twitter][twitter], [apply 
 
 ### Contributors
 
+<!-- markdownlint-disable -->
 |  [![Erik Osterman][osterman_avatar]][osterman_homepage]<br/>[Erik Osterman][osterman_homepage] | [![Andriy Knysh][aknysh_avatar]][aknysh_homepage]<br/>[Andriy Knysh][aknysh_homepage] | [![Vladimir][SweetOps_avatar]][SweetOps_homepage]<br/>[Vladimir][SweetOps_homepage] |
 |---|---|---|
+<!-- markdownlint-restore -->
 
   [osterman_homepage]: https://github.com/osterman
   [osterman_avatar]: https://img.cloudposse.com/150x150/https://github.com/osterman.png

--- a/README.md
+++ b/README.md
@@ -192,10 +192,10 @@ Available targets:
 | Name | Description |
 |------|-------------|
 | hostname | Bucket hostname |
-| s3\_bucket\_arn | ARN identifier of website bucket |
-| s3\_bucket\_domain\_name | Name of website bucket |
+| s3\_bucket\_arn | ARN identifier of the website bucket |
+| s3\_bucket\_domain\_name | Name of the website bucket |
 | s3\_bucket\_hosted\_zone\_id | The Route 53 Hosted Zone ID for this bucket's region |
-| s3\_bucket\_name | DNS record of website bucket |
+| s3\_bucket\_name | DNS record of the website bucket |
 | s3\_bucket\_website\_domain | The domain of the website endpoint |
 | s3\_bucket\_website\_endpoint | The website endpoint URL |
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Available targets:
 | deployment\_actions | List of actions to permit deployment ARNs to perform | `list(string)` | <pre>[<br>  "s3:PutObject",<br>  "s3:PutObjectAcl",<br>  "s3:GetObject",<br>  "s3:DeleteObject",<br>  "s3:ListBucket",<br>  "s3:ListBucketMultipartUploads",<br>  "s3:GetBucketLocation",<br>  "s3:AbortMultipartUpload"<br>]</pre> | no |
 | deployment\_arns | (Optional) Map of deployment ARNs to lists of S3 path prefixes to grant `deployment_actions` permissions | `map(any)` | `{}` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| encryption\_enabled | When set to 'true' the resource will have AES256 encryption enabled by default | `bool` | `false` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | error\_document | An absolute path to the document to return in case of a 4XX error | `string` | `"404.html"` | no |
 | force\_destroy | Delete all objects from the bucket so that the bucket can be destroyed without error (e.g. `true` or `false`) | `bool` | `false` | no |
@@ -301,7 +302,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.md
+++ b/README.md
@@ -150,14 +150,14 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| attributes | Additional attributes (e.g. `policy` or `role`) | `list(string)` | `[]` | no |
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | cors\_allowed\_headers | List of allowed headers | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | cors\_allowed\_methods | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br>  "GET"<br>]</pre> | no |
 | cors\_allowed\_origins | List of allowed origins (e.g. example.com, test.com) | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | cors\_expose\_headers | List of expose header in the response | `list(string)` | <pre>[<br>  "ETag"<br>]</pre> | no |
 | cors\_max\_age\_seconds | Time in seconds that browser can cache the response | `number` | `3600` | no |
-| delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | `string` | `"-"` | no |
+| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | deployment\_actions | List of actions to permit deployment ARNs to perform | `list(string)` | <pre>[<br>  "s3:PutObject",<br>  "s3:PutObjectAcl",<br>  "s3:GetObject",<br>  "s3:DeleteObject",<br>  "s3:ListBucket",<br>  "s3:ListBucketMultipartUploads",<br>  "s3:GetBucketLocation",<br>  "s3:AbortMultipartUpload"<br>]</pre> | no |
 | deployment\_arns | (Optional) Map of deployment ARNs to lists of S3 path prefixes to grant `deployment_actions` permissions | `map(any)` | `{}` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -172,8 +172,8 @@ Available targets:
 | logs\_expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
 | logs\_glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
 | logs\_standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier | `number` | `30` | no |
-| name | The Name of the application or solution  (e.g. `bastion` or `portal`) | `string` | n/a | yes |
-| namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
+| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent object versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier infrequent access tier | `number` | `30` | no |
 | parent\_zone\_id | ID of the hosted zone to contain the record | `string` | `""` | no |
@@ -181,11 +181,10 @@ Available targets:
 | prefix | Prefix identifying one or more objects to which the rule applies | `string` | `""` | no |
 | redirect\_all\_requests\_to | A hostname to redirect all website requests for this bucket to. If this is set `index_document` will be ignored | `string` | `""` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| region | AWS region this bucket should reside in | `string` | `""` | no |
 | replication\_source\_principal\_arns | (Optional) List of principal ARNs to grant replication access from different AWS accounts | `list(string)` | `[]` | no |
 | routing\_rules | A json array containing routing rules describing redirect behavior and when redirects are applied | `string` | `""` | no |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | versioning\_enabled | Enable or disable versioning | `bool` | `false` | no |
 
 ## Outputs

--- a/README.yaml
+++ b/README.yaml
@@ -57,7 +57,9 @@ usage: |-
 
   ```hcl
   module "website" {
-    source    = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=master"
+    source = "cloudposse/s3-website/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
     namespace = "eg"
     stage     = "prod"
     name      = "app"
@@ -77,7 +79,9 @@ usage: |-
 
   ```hcl
   module "website_with_cname" {
-    source         = "git::https://github.com/cloudposse/terraform-aws-s3-website.git?ref=master"
+    source = "cloudposse/s3-website/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version = "x.x.x"
     namespace      = "eg"
     stage          = "prod"
     name           = "app"

--- a/context.tf
+++ b/context.tf
@@ -1,0 +1,169 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.22.0" // requires Terraform >= 0.12.26
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = object({
+    enabled             = bool
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    delimiter           = string
+    attributes          = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+    label_order         = list(string)
+    id_length_limit     = number
+  })
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters.
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,14 +19,14 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
-| attributes | Additional attributes (e.g. `policy` or `role`) | `list(string)` | `[]` | no |
+| attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
 | context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | cors\_allowed\_headers | List of allowed headers | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | cors\_allowed\_methods | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br>  "GET"<br>]</pre> | no |
 | cors\_allowed\_origins | List of allowed origins (e.g. example.com, test.com) | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | cors\_expose\_headers | List of expose header in the response | `list(string)` | <pre>[<br>  "ETag"<br>]</pre> | no |
 | cors\_max\_age\_seconds | Time in seconds that browser can cache the response | `number` | `3600` | no |
-| delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | `string` | `"-"` | no |
+| delimiter | Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.<br>Defaults to `-` (hyphen). Set to `""` to use no delimiter at all. | `string` | `null` | no |
 | deployment\_actions | List of actions to permit deployment ARNs to perform | `list(string)` | <pre>[<br>  "s3:PutObject",<br>  "s3:PutObjectAcl",<br>  "s3:GetObject",<br>  "s3:DeleteObject",<br>  "s3:ListBucket",<br>  "s3:ListBucketMultipartUploads",<br>  "s3:GetBucketLocation",<br>  "s3:AbortMultipartUpload"<br>]</pre> | no |
 | deployment\_arns | (Optional) Map of deployment ARNs to lists of S3 path prefixes to grant `deployment_actions` permissions | `map(any)` | `{}` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -41,8 +41,8 @@
 | logs\_expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
 | logs\_glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
 | logs\_standard\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier | `number` | `30` | no |
-| name | The Name of the application or solution  (e.g. `bastion` or `portal`) | `string` | n/a | yes |
-| namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
+| name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |
+| namespace | Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp' | `string` | `null` | no |
 | noncurrent\_version\_expiration\_days | Specifies when noncurrent object versions expire | `number` | `90` | no |
 | noncurrent\_version\_transition\_days | Number of days to persist in the standard storage tier before moving to the glacier tier infrequent access tier | `number` | `30` | no |
 | parent\_zone\_id | ID of the hosted zone to contain the record | `string` | `""` | no |
@@ -50,11 +50,10 @@
 | prefix | Prefix identifying one or more objects to which the rule applies | `string` | `""` | no |
 | redirect\_all\_requests\_to | A hostname to redirect all website requests for this bucket to. If this is set `index_document` will be ignored | `string` | `""` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| region | AWS region this bucket should reside in | `string` | `""` | no |
 | replication\_source\_principal\_arns | (Optional) List of principal ARNs to grant replication access from different AWS accounts | `list(string)` | `[]` | no |
 | routing\_rules | A json array containing routing rules describing redirect behavior and when redirects are applied | `string` | `""` | no |
-| stage | Stage (e.g. `prod`, `dev`, `staging`) | `string` | `""` | no |
-| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')`) | `map(string)` | `{}` | no |
+| stage | Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release' | `string` | `null` | no |
+| tags | Additional tags (e.g. `map('BusinessUnit','XYZ')` | `map(string)` | `{}` | no |
 | versioning\_enabled | Enable or disable versioning | `bool` | `false` | no |
 
 ## Outputs

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,6 +30,7 @@
 | deployment\_actions | List of actions to permit deployment ARNs to perform | `list(string)` | <pre>[<br>  "s3:PutObject",<br>  "s3:PutObjectAcl",<br>  "s3:GetObject",<br>  "s3:DeleteObject",<br>  "s3:ListBucket",<br>  "s3:ListBucketMultipartUploads",<br>  "s3:GetBucketLocation",<br>  "s3:AbortMultipartUpload"<br>]</pre> | no |
 | deployment\_arns | (Optional) Map of deployment ARNs to lists of S3 path prefixes to grant `deployment_actions` permissions | `map(any)` | `{}` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| encryption\_enabled | When set to 'true' the resource will have AES256 encryption enabled by default | `bool` | `false` | no |
 | environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | error\_document | An absolute path to the document to return in case of a 4XX error | `string` | `"404.html"` | no |
 | force\_destroy | Delete all objects from the bucket so that the bucket can be destroyed without error (e.g. `true` or `false`) | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -61,10 +61,10 @@
 | Name | Description |
 |------|-------------|
 | hostname | Bucket hostname |
-| s3\_bucket\_arn | ARN identifier of website bucket |
-| s3\_bucket\_domain\_name | Name of website bucket |
+| s3\_bucket\_arn | ARN identifier of the website bucket |
+| s3\_bucket\_domain\_name | Name of the website bucket |
 | s3\_bucket\_hosted\_zone\_id | The Route 53 Hosted Zone ID for this bucket's region |
-| s3\_bucket\_name | DNS record of website bucket |
+| s3\_bucket\_name | DNS record of the website bucket |
 | s3\_bucket\_website\_domain | The domain of the website endpoint |
 | s3\_bucket\_website\_endpoint | The website endpoint URL |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,23 +1,26 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
+| terraform | >= 0.12.26 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| additional\_tag\_map | Additional tags for appending to tags\_as\_list\_of\_maps. Not added to `tags`. | `map(string)` | `{}` | no |
 | attributes | Additional attributes (e.g. `policy` or `role`) | `list(string)` | `[]` | no |
+| context | Single object for setting entire context at once.<br>See description of individual variables for details.<br>Leave string and numeric variables as `null` to use default value.<br>Individual variable settings (non-null) override settings in context object,<br>except for attributes, tags, and additional\_tag\_map, which are merged. | <pre>object({<br>    enabled             = bool<br>    namespace           = string<br>    environment         = string<br>    stage               = string<br>    name                = string<br>    delimiter           = string<br>    attributes          = list(string)<br>    tags                = map(string)<br>    additional_tag_map  = map(string)<br>    regex_replace_chars = string<br>    label_order         = list(string)<br>    id_length_limit     = number<br>  })</pre> | <pre>{<br>  "additional_tag_map": {},<br>  "attributes": [],<br>  "delimiter": null,<br>  "enabled": true,<br>  "environment": null,<br>  "id_length_limit": null,<br>  "label_order": [],<br>  "name": null,<br>  "namespace": null,<br>  "regex_replace_chars": null,<br>  "stage": null,<br>  "tags": {}<br>}</pre> | no |
 | cors\_allowed\_headers | List of allowed headers | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
 | cors\_allowed\_methods | List of allowed methods (e.g. GET, PUT, POST, DELETE, HEAD) | `list(string)` | <pre>[<br>  "GET"<br>]</pre> | no |
 | cors\_allowed\_origins | List of allowed origins (e.g. example.com, test.com) | `list(string)` | <pre>[<br>  "*"<br>]</pre> | no |
@@ -26,10 +29,14 @@
 | delimiter | Delimiter to be used between `name`, `namespace`, `stage`, etc. | `string` | `"-"` | no |
 | deployment\_actions | List of actions to permit deployment ARNs to perform | `list(string)` | <pre>[<br>  "s3:PutObject",<br>  "s3:PutObjectAcl",<br>  "s3:GetObject",<br>  "s3:DeleteObject",<br>  "s3:ListBucket",<br>  "s3:ListBucketMultipartUploads",<br>  "s3:GetBucketLocation",<br>  "s3:AbortMultipartUpload"<br>]</pre> | no |
 | deployment\_arns | (Optional) Map of deployment ARNs to lists of S3 path prefixes to grant `deployment_actions` permissions | `map(any)` | `{}` | no |
+| enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
+| environment | Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT' | `string` | `null` | no |
 | error\_document | An absolute path to the document to return in case of a 4XX error | `string` | `"404.html"` | no |
 | force\_destroy | Delete all objects from the bucket so that the bucket can be destroyed without error (e.g. `true` or `false`) | `bool` | `false` | no |
 | hostname | Name of website bucket in `fqdn` format (e.g. `test.example.com`). IMPORTANT! Do not add trailing dot (`.`) | `string` | n/a | yes |
+| id\_length\_limit | Limit `id` to this many characters.<br>Set to `0` for unlimited length.<br>Set to `null` for default, which is `0`.<br>Does not affect `id_full`. | `number` | `null` | no |
 | index\_document | Amazon S3 returns this index document when requests are made to the root domain or any of the subfolders | `string` | `"index.html"` | no |
+| label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | lifecycle\_rule\_enabled | Enable or disable lifecycle rule | `bool` | `false` | no |
 | logs\_expiration\_days | Number of days after which to expunge the objects | `number` | `90` | no |
 | logs\_glacier\_transition\_days | Number of days after which to move the data to the glacier storage tier | `number` | `60` | no |
@@ -42,6 +49,7 @@
 | parent\_zone\_name | Name of the hosted zone to contain the record | `string` | `""` | no |
 | prefix | Prefix identifying one or more objects to which the rule applies | `string` | `""` | no |
 | redirect\_all\_requests\_to | A hostname to redirect all website requests for this bucket to. If this is set `index_document` will be ignored | `string` | `""` | no |
+| regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
 | region | AWS region this bucket should reside in | `string` | `""` | no |
 | replication\_source\_principal\_arns | (Optional) List of principal ARNs to grant replication access from different AWS accounts | `list(string)` | `[]` | no |
 | routing\_rules | A json array containing routing rules describing redirect behavior and when redirects are applied | `string` | `""` | no |
@@ -61,3 +69,4 @@
 | s3\_bucket\_website\_domain | The domain of the website endpoint |
 | s3\_bucket\_website\_endpoint | The website endpoint URL |
 
+<!-- markdownlint-restore -->

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -1,0 +1,169 @@
+#
+# ONLY EDIT THIS FILE IN github.com/cloudposse/terraform-null-label
+# All other instances of this file should be a copy of that one
+#
+#
+# Copy this file from https://github.com/cloudposse/terraform-null-label/blob/master/exports/context.tf
+# and then place it in your Terraform module to automatically get
+# Cloud Posse's standard configuration inputs suitable for passing
+# to Cloud Posse modules.
+#
+# Modules should access the whole context as `module.this.context`
+# to get the input variables with nulls for defaults,
+# for example `context = module.this.context`,
+# and access individual variables as `module.this.<var>`,
+# with final values filled in.
+#
+# For example, when using defaults, `module.this.context.delimiter`
+# will be null, and `module.this.delimiter` will be `-` (hyphen).
+#
+
+
+module "this" {
+  source  = "cloudposse/label/null"
+  version = "0.22.0" // requires Terraform >= 0.12.26
+
+  enabled             = var.enabled
+  namespace           = var.namespace
+  environment         = var.environment
+  stage               = var.stage
+  name                = var.name
+  delimiter           = var.delimiter
+  attributes          = var.attributes
+  tags                = var.tags
+  additional_tag_map  = var.additional_tag_map
+  label_order         = var.label_order
+  regex_replace_chars = var.regex_replace_chars
+  id_length_limit     = var.id_length_limit
+
+  context = var.context
+}
+
+# Copy contents of cloudposse/terraform-null-label/variables.tf here
+
+variable "context" {
+  type = object({
+    enabled             = bool
+    namespace           = string
+    environment         = string
+    stage               = string
+    name                = string
+    delimiter           = string
+    attributes          = list(string)
+    tags                = map(string)
+    additional_tag_map  = map(string)
+    regex_replace_chars = string
+    label_order         = list(string)
+    id_length_limit     = number
+  })
+  default = {
+    enabled             = true
+    namespace           = null
+    environment         = null
+    stage               = null
+    name                = null
+    delimiter           = null
+    attributes          = []
+    tags                = {}
+    additional_tag_map  = {}
+    regex_replace_chars = null
+    label_order         = []
+    id_length_limit     = null
+  }
+  description = <<-EOT
+    Single object for setting entire context at once.
+    See description of individual variables for details.
+    Leave string and numeric variables as `null` to use default value.
+    Individual variable settings (non-null) override settings in context object,
+    except for attributes, tags, and additional_tag_map, which are merged.
+  EOT
+}
+
+variable "enabled" {
+  type        = bool
+  default     = null
+  description = "Set to false to prevent the module from creating any resources"
+}
+
+variable "namespace" {
+  type        = string
+  default     = null
+  description = "Namespace, which could be your organization name or abbreviation, e.g. 'eg' or 'cp'"
+}
+
+variable "environment" {
+  type        = string
+  default     = null
+  description = "Environment, e.g. 'uw2', 'us-west-2', OR 'prod', 'staging', 'dev', 'UAT'"
+}
+
+variable "stage" {
+  type        = string
+  default     = null
+  description = "Stage, e.g. 'prod', 'staging', 'dev', OR 'source', 'build', 'test', 'deploy', 'release'"
+}
+
+variable "name" {
+  type        = string
+  default     = null
+  description = "Solution name, e.g. 'app' or 'jenkins'"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Delimiter to be used between `namespace`, `environment`, `stage`, `name` and `attributes`.
+    Defaults to `-` (hyphen). Set to `""` to use no delimiter at all.
+  EOT
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `1`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`"
+}
+
+variable "additional_tag_map" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags for appending to tags_as_list_of_maps. Not added to `tags`."
+}
+
+variable "label_order" {
+  type        = list(string)
+  default     = null
+  description = <<-EOT
+    The naming order of the id output and Name tag.
+    Defaults to ["namespace", "environment", "stage", "name", "attributes"].
+    You can omit any of the 5 elements, but at least one must be present.
+  EOT
+}
+
+variable "regex_replace_chars" {
+  type        = string
+  default     = null
+  description = <<-EOT
+    Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.
+    If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits.
+  EOT
+}
+
+variable "id_length_limit" {
+  type        = number
+  default     = null
+  description = <<-EOT
+    Limit `id` to this many characters.
+    Set to `0` for unlimited length.
+    Set to `null` for default, which is `0`.
+    Does not affect `id_full`.
+  EOT
+}
+
+#### End of copy of cloudposse/terraform-null-label/variables.tf

--- a/examples/complete/fixtures.us-west-1.tfvars
+++ b/examples/complete/fixtures.us-west-1.tfvars
@@ -12,3 +12,5 @@ stage = "test"
 parent_zone_name = "testing.cloudposse.co"
 
 force_destroy = true
+
+encryption_enabled = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,10 +3,11 @@ provider "aws" {
 }
 
 module "s3_website" {
-  source           = "../../"
-  hostname         = var.hostname
-  parent_zone_name = var.parent_zone_name
-  force_destroy    = var.force_destroy
+  source             = "../../"
+  hostname           = var.hostname
+  parent_zone_name   = var.parent_zone_name
+  force_destroy      = var.force_destroy
+  encryption_enabled = var.encryption_enabled
 
   context = module.this.context
 }

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,10 +4,9 @@ provider "aws" {
 
 module "s3_website" {
   source           = "../../"
-  namespace        = var.namespace
-  stage            = var.stage
-  name             = var.name
   hostname         = var.hostname
   parent_zone_name = var.parent_zone_name
   force_destroy    = var.force_destroy
+
+  context = module.this.context
 }

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -3,21 +3,6 @@ variable "region" {
   description = "AWS region"
 }
 
-variable "name" {
-  type        = string
-  description = "The Name of the application or solution  (e.g. `bastion` or `portal`)"
-}
-
-variable "namespace" {
-  type        = string
-  description = "Namespace (e.g. `eg` or `cp`)"
-}
-
-variable "stage" {
-  type        = string
-  description = "Stage (e.g. `prod`, `dev`, `staging`)"
-}
-
 variable "hostname" {
   type        = string
   description = "Name of website bucket in `fqdn` format (e.g. `test.example.com`). IMPORTANT! Do not add trailing dot (`.`)"

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -17,3 +17,9 @@ variable "force_destroy" {
   type        = bool
   description = "Delete all objects from the bucket so that the bucket can be destroyed without error (e.g. `true` or `false`)"
 }
+
+variable "encryption_enabled" {
+  type        = bool
+  default     = false
+  description = "When set to 'true' the resource will have AES256 encryption enabled by default"
+}

--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ module "logs" {
   standard_transition_days = var.logs_standard_transition_days
   glacier_transition_days  = var.logs_glacier_transition_days
   expiration_days          = var.logs_expiration_days
+  force_destroy            = var.force_destroy
 
   context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -16,32 +16,27 @@ locals {
 }
 
 module "logs" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-s3-log-storage.git?ref=tags/0.13.1"
-  name                     = var.name
-  stage                    = var.stage
-  namespace                = var.namespace
-  delimiter                = var.delimiter
-  attributes               = compact(concat(var.attributes, ["logs"]))
+  source                   = "cloudposse/s3-log-storage/aws"
+  version                  = "0.16.0"
+  attributes               = ["logs"]
   standard_transition_days = var.logs_standard_transition_days
   glacier_transition_days  = var.logs_glacier_transition_days
   expiration_days          = var.logs_expiration_days
+
+  context = module.this.context
 }
 
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
-  namespace  = var.namespace
-  stage      = var.stage
-  name       = var.name
-  delimiter  = var.delimiter
-  attributes = compact(concat(var.attributes, ["origin"]))
-  tags       = var.tags
+  source     = "cloudposse/label/null"
+  version    = "0.22.0"
+  attributes = ["origin"]
+  context    = module.this.context
 }
 
 resource "aws_s3_bucket" "default" {
   bucket        = var.hostname
   acl           = "public-read"
   tags          = module.default_label.tags
-  region        = var.region
   force_destroy = var.force_destroy
 
   logging {
@@ -232,10 +227,13 @@ data "aws_iam_policy_document" "deployment" {
 }
 
 module "dns" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-route53-alias.git?ref=tags/0.8.0"
+  source           = "cloudposse/route53-alias/aws"
+  version          = "0.10.0"
   aliases          = compact([signum(length(var.parent_zone_id)) == 1 || signum(length(var.parent_zone_name)) == 1 ? var.hostname : ""])
   parent_zone_id   = var.parent_zone_id
   parent_zone_name = var.parent_zone_name
   target_dns_name  = aws_s3_bucket.default.website_domain
   target_zone_id   = aws_s3_bucket.default.hosted_zone_id
+
+  context = module.this.context
 }

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,18 @@ resource "aws_s3_bucket" "default" {
       days = var.noncurrent_version_expiration_days
     }
   }
+
+  dynamic "server_side_encryption_configuration" {
+    for_each = var.encryption_enabled ? ["true"] : []
+
+    content {
+      rule {
+        apply_server_side_encryption_by_default {
+          sse_algorithm = "AES256"
+        }
+      }
+    }
+  }
 }
 
 # AWS only supports a single bucket policy on a bucket. You can combine multiple Statements into a single policy, but not attach multiple policies.

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,17 +5,17 @@ output "hostname" {
 
 output "s3_bucket_name" {
   value       = aws_s3_bucket.default.id
-  description = "DNS record of website bucket"
+  description = "DNS record of the website bucket"
 }
 
 output "s3_bucket_domain_name" {
   value       = aws_s3_bucket.default.bucket_domain_name
-  description = "Name of website bucket"
+  description = "Name of the website bucket"
 }
 
 output "s3_bucket_arn" {
   value       = aws_s3_bucket.default.arn
-  description = "ARN identifier of website bucket"
+  description = "ARN identifier of the website bucket"
 }
 
 output "s3_bucket_website_endpoint" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,38 +1,3 @@
-variable "name" {
-  type        = string
-  description = "The Name of the application or solution  (e.g. `bastion` or `portal`)"
-}
-
-variable "namespace" {
-  type        = string
-  description = "Namespace (e.g. `eg` or `cp`)"
-  default     = ""
-}
-
-variable "stage" {
-  type        = string
-  description = "Stage (e.g. `prod`, `dev`, `staging`)"
-  default     = ""
-}
-
-variable "attributes" {
-  type        = list(string)
-  default     = []
-  description = "Additional attributes (e.g. `policy` or `role`)"
-}
-
-variable "tags" {
-  type        = map(string)
-  default     = {}
-  description = "Additional tags (e.g. `map('BusinessUnit','XYZ')`)"
-}
-
-variable "delimiter" {
-  type        = string
-  default     = "-"
-  description = "Delimiter to be used between `name`, `namespace`, `stage`, etc."
-}
-
 variable "hostname" {
   type        = string
   description = "Name of website bucket in `fqdn` format (e.g. `test.example.com`). IMPORTANT! Do not add trailing dot (`.`)"
@@ -144,12 +109,6 @@ variable "noncurrent_version_expiration_days" {
   type        = number
   default     = 90
   description = "Specifies when noncurrent object versions expire"
-}
-
-variable "region" {
-  type        = string
-  default     = ""
-  description = "AWS region this bucket should reside in"
 }
 
 variable "versioning_enabled" {

--- a/variables.tf
+++ b/variables.tf
@@ -140,3 +140,9 @@ variable "deployment_actions" {
   default     = ["s3:PutObject", "s3:PutObjectAcl", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket", "s3:ListBucketMultipartUploads", "s3:GetBucketLocation", "s3:AbortMultipartUpload"]
   description = "List of actions to permit deployment ARNs to perform"
 }
+
+variable "encryption_enabled" {
+  type        = bool
+  default     = false
+  description = "When set to 'true' the resource will have AES256 encryption enabled by default"
+}

--- a/versions.tf
+++ b/versions.tf
@@ -1,9 +1,18 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws   = "~> 2.0"
-    local = "~> 1.2"
-    null  = "~> 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.2"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }


### PR DESCRIPTION
## what
- Upgrade to support Terraform 0.14 and bring up to current Cloud Posse standard

## why
- Support Terraform 0.14

supersedes and closes #38 
supersedes and closes #44 
supersedes and closes #47 