### PR TITLE
Add an optional list of IP CIDRs which can access the S3 website.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -153,6 +153,34 @@ data "aws_iam_policy_document" "default" {
     }
   }
 
+  dynamic "statement" {
+    for_each = flatten(var.trusted_ips) != [] ? [1] : []
+
+    # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_examples_aws_deny-ip.html
+    content {
+      sid       = "AllowTrustedIPsOnly"
+      effect    = "Deny"
+      actions   = ["s3:*"]
+      resources = [local.bucket_arn, "${local.bucket_arn}/*"]
+
+      principals {
+        identifiers = ["*"]
+        type        = "*"
+      }
+
+      condition {
+        test     = "NotIpAddress"
+        values   = var.trusted_ips
+        variable = "aws:SourceIp"
+      }
+      condition {
+        test     = "Bool"
+        values   = ["false"]
+        variable = "aws:ViaAWSService"
+      }
+    }
+  }
+
   # Support replication ARNs
   dynamic "statement" {
     for_each = flatten(data.aws_iam_policy_document.replication.*.statement)

--- a/variables.tf
+++ b/variables.tf
@@ -158,3 +158,9 @@ variable "allow_ssl_requests_only" {
   default     = false
   description = "Set to `true` to require requests to use Secure Socket Layer (HTTPS/SSL). This will explicitly deny access to HTTP requests"
 }
+
+variable "trusted_ips" {
+  type        = list(string)
+  default     = []
+  description = "(Optional) List of IP CIDRs which can access the S3 website"
+}


### PR DESCRIPTION
## what
* We have a need to restrict access to the S3 website.  This change allows adding the `aws:SourceIp` condition to the IAM bucket policy via the new optional `trusted_ips` variable.

## why
* S3 website are normally public, but we have a need to not allow the work access to the contents.  Source IP restrictions help to solve that.

